### PR TITLE
Possibility to set context for SocketClient

### DIFF
--- a/src/Connection/Socket.php
+++ b/src/Connection/Socket.php
@@ -89,7 +89,7 @@ XML;
      */
     public static function factory(Options $options)
     {
-        $socket = new SocketClient($options->getAddress());
+        $socket = new SocketClient($options->getAddress(), $options->getContextOptions());
         $object = new static($socket);
         $object->setOptions($options);
         return $object;

--- a/src/Options.php
+++ b/src/Options.php
@@ -128,6 +128,15 @@ class Options
         'plain'      => '\\Fabiang\\Xmpp\\EventListener\\Stream\\Authentication\\Plain'
     );
 
+
+    /**
+     * Options used to create a stream context
+     *
+     * @var array
+     */
+    protected $contextOptions = array();
+
+
     /**
      * Constructor.
      *
@@ -411,6 +420,28 @@ class Options
     public function setTimeout($timeout)
     {
         $this->timeout = (int) $timeout;
+        return $this;
+    }
+
+    /**
+     * Get context options for connection
+     *
+     * @return array
+     */
+    public function getContextOptions()
+    {
+        return $this->contextOptions;
+    }
+
+    /**
+     *  Set context options for connection
+     *
+     * @param array $contextOptions
+     * @return \Fabiang\Xmpp\Options
+     */
+    public function setContextOptions($contextOptions)
+    {
+        $this->contextOptions = (array) $contextOptions;
         return $this;
     }
 }

--- a/src/Stream/SocketClient.php
+++ b/src/Stream/SocketClient.php
@@ -63,20 +63,30 @@ class SocketClient
      */
     protected $address;
 
+
+    /**
+     * Options used to create a stream context
+     * @see http://php.net/manual/en/function.stream-context-create.php
+     *
+     * @var array
+     */
+    protected $options;
+
     /**
      * Constructor takes address as argument.
      *
      * @param string $address
      */
-    public function __construct($address)
+    public function __construct($address, $options = null)
     {
         $this->address = $address;
+        $this->options = $options;
     }
 
     /**
      * Connect.
      *
-     * @param integer $timeout    Timeout for connection
+     * @param integer $timeout Timeout for connection
      * @param boolean $persistent Persitent connection
      * @return void
      */
@@ -91,7 +101,8 @@ class SocketClient
         // call stream_socket_client with custom error handler enabled
         $handler = new ErrorHandler(
             function ($address, $timeout, $flags) {
-                return stream_socket_client($address, $errno, $errstr, $timeout, $flags);
+                $context = stream_context_create($this->options);
+                return stream_socket_client($address, $errno, $errstr, $timeout, $flags, $context);
             },
             $this->address,
             $timeout,
@@ -106,9 +117,9 @@ class SocketClient
     /**
      * Reconnect and optionally use different address.
      *
-     * @param string  $address
+     * @param string $address
      * @param integer $timeout
-     * @param bool    $persistent
+     * @param bool $persistent
      */
     public function reconnect($address = null, $timeout = 30, $persistent = false)
     {
@@ -139,7 +150,7 @@ class SocketClient
      */
     public function setBlocking($flag = true)
     {
-        stream_set_blocking($this->resource, (int) $flag);
+        stream_set_blocking($this->resource, (int)$flag);
         return $this;
     }
 
@@ -157,7 +168,7 @@ class SocketClient
     /**
      * Write to stream.
      *
-     * @param string  $string String
+     * @param string $string String
      * @param integer $length Limit
      * @return void
      */
@@ -173,7 +184,7 @@ class SocketClient
     /**
      * Enable/disable cryptography on stream.
      *
-     * @param boolean $enable     Flag
+     * @param boolean $enable Flag
      * @param integer $cryptoType One of the STREAM_CRYPTO_METHOD_* constants.
      * @return void
      * @throws InvalidArgumentException

--- a/src/Stream/SocketClient.php
+++ b/src/Stream/SocketClient.php
@@ -101,7 +101,7 @@ class SocketClient
         // call stream_socket_client with custom error handler enabled
         $handler = new ErrorHandler(
             function ($address, $timeout, $flags) {
-                $context = stream_context_create($this->options);
+                $context = (null != $this->options) ? stream_context_create($this->options) : null;
                 return stream_socket_client($address, $errno, $errstr, $timeout, $flags, $context);
             },
             $this->address,


### PR DESCRIPTION
When opening a socket connection with  _stream_socket_client_ there is no possibility to add the last parameter $context. 

I extended the Options class with an additional variable to accept those context options. When creating a new _SocketClient_ instance those options are passed as a second parameter and if set are used to create new socket context with _stream_context_create_ .

**Possible usage:** setting options for ssl verification

`$options->setContextOptions(['ssl' => ['verify_peer' => false,'verify_peer_name' => false]]);`
